### PR TITLE
chore(deps): remediate security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "qs": ">=6.14.1",
       "form-data": ">=4.0.4",
       "axios": "1.13.5",
-      "undici": "6.23.0",
+      "undici": "6.24.0",
       "@isaacs/brace-expansion": ">=5.0.1"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   qs: '>=6.14.1'
   form-data: '>=4.0.4'
   axios: 1.13.5
-  undici: 6.23.0
+  undici: 6.24.0
   '@isaacs/brace-expansion': '>=5.0.1'
 
 importers:
@@ -780,8 +780,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
+  undici@6.24.0:
+    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
     engines: {node: '>=18.17'}
 
   universal-user-agent@6.0.1:
@@ -830,12 +830,12 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.1)
       '@octokit/request': 8.4.1
       '@octokit/request-error': 5.1.1
-      undici: 6.23.0
+      undici: 6.24.0
 
   '@actions/http-client@2.2.3':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.23.0
+      undici: 6.24.0
 
   '@actions/io@1.1.3': {}
 
@@ -1457,7 +1457,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.23.0: {}
+  undici@6.24.0: {}
 
   universal-user-agent@6.0.1: {}
 


### PR DESCRIPTION
- high axios fixed:[1.13.5] [CVE-2026-25639] [Axios is Vulnerable to Denial of Service via __proto__ Key in mergeConfig]
- high flatted fixed:[3.4.0] [CVE-2026-32141] [flatted vulnerable to unbounded recursion DoS in parse() revive phase]
- high koa fixed:[3.1.2] [CVE-2026-27959] [Koa has Host Header Injection via ctx.hostname]
- high minimatch fixed:[10.2.1,10.2.3,3.1.3,3.1.4,9.0.6,9.0.7] [CVE-2026-26996,CVE-2026-27903,CVE-2026-27904] [minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions; minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments; minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern]
- high rollup fixed:[4.59.0] [CVE-2026-27606] [Rollup 4 has Arbitrary File Write via Path Traversal]
- high undici fixed:[6.24.0] [CVE-2026-1526,CVE-2026-1528,CVE-2026-2229] [Undici has Unbounded Memory Consumption in WebSocket permessage-deflate Decompression; Undici has Unhandled Exception in WebSocket Client Due to Invalid server_max_window_bits Validation; Undici: Malicious WebSocket 64-bit length overflows parser and crashes the client]
- medium ajv fixed:[6.14.0] [CVE-2025-69873] [ajv has ReDoS when using $data option]
- medium undici fixed:[6.24.0] [CVE-2026-1525,CVE-2026-1527] [Undici has CRLF Injection in undici via `upgrade` option; Undici has an HTTP Request/Response Smuggling issue]