### PR TITLE
fix: bump axios to 1.15.2 to resolve CVE-2026-42264

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "overrides": {
       "qs": ">=6.14.1",
       "form-data": ">=4.0.4",
-      "axios": "1.15.1",
+      "axios": "1.15.2",
       "undici": "6.24.0",
       "@isaacs/brace-expansion": ">=5.0.1",
       "@eslint/plugin-kit": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   qs: '>=6.14.1'
   form-data: '>=4.0.4'
-  axios: 1.15.1
+  axios: 1.15.2
   undici: 6.24.0
   '@isaacs/brace-expansion': '>=5.0.1'
   '@eslint/plugin-kit': ^0.5.0
@@ -1111,10 +1111,10 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: 1.15.1
+      axios: 1.15.2
 
-  axios@1.15.1:
-    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -2497,7 +2497,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 2.3.1
       adm-zip: 0.5.17
       ansi-colors: 4.1.3
-      axios: 1.15.1(debug@4.4.3)
+      axios: 1.15.2(debug@4.4.3)
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
       node-schedule: 2.1.1
@@ -2994,12 +2994,12 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  axios-retry@4.5.0(axios@1.15.1(debug@4.4.3)):
+  axios-retry@4.5.0(axios@1.15.2(debug@4.4.3)):
     dependencies:
-      axios: 1.15.1(debug@4.4.3)
+      axios: 1.15.2(debug@4.4.3)
       is-retry-allowed: 2.2.0
 
-  axios@1.15.1(debug@4.4.3):
+  axios@1.15.2(debug@4.4.3):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.4
@@ -3969,8 +3969,8 @@ snapshots:
   zephyr-agent@0.1.16(https-proxy-agent@7.0.6):
     dependencies:
       '@toon-format/toon': 0.9.0
-      axios: 1.15.1(debug@4.4.3)
-      axios-retry: 4.5.0(axios@1.15.1(debug@4.4.3))
+      axios: 1.15.2(debug@4.4.3)
+      axios-retry: 4.5.0(axios@1.15.2(debug@4.4.3))
       debug: 4.4.3
       eventsource: 4.1.0
       git-url-parse: 15.0.0


### PR DESCRIPTION
🎫 **Ticket**
N/A

🧠 **Why**
The root `pnpm.overrides` entry pinned `axios` to `1.15.1`, which remains affected by `CVE-2026-42264`. This updates the override to the minimal fixed version and refreshes the lockfile accordingly.

📝 **What changed**
- Changed the root `pnpm.overrides.axios` value from `1.15.1` to `1.15.2`
- Regenerated `pnpm-lock.yaml` so all resolved `axios` entries now use `1.15.2`

🧪 **How to test**
1. Run `pnpm install`
2. Confirm `package.json` contains `pnpm.overrides.axios: 1.15.2`
3. Confirm `pnpm-lock.yaml` resolves `axios` to `1.15.2`
4. Run any dependency or vulnerability scan that previously flagged `CVE-2026-42264`

📸 **Screenshots**
N/A