### PR TITLE
fix(deps): remediate follow-redirects advisory (Vanta)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "@isaacs/brace-expansion": ">=5.0.1",
       "@eslint/plugin-kit": "^0.5.0",
       "koa": "3.1.2",
-      "picomatch": "^4.0.4"
+      "picomatch": "^4.0.4",
+      "follow-redirects@<1.16.0": ">=1.16.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   '@eslint/plugin-kit': ^0.5.0
   koa: 3.1.2
   picomatch: ^4.0.4
+  follow-redirects@<1.16.0: '>=1.16.0'
 
 importers:
 
@@ -1399,8 +1400,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -3001,7 +3002,7 @@ snapshots:
 
   axios@1.15.2(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.4
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -3297,7 +3298,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
 


### PR DESCRIPTION
### What changed

Added a pinned `pnpm.overrides` entry for `follow-redirects` (transitive dep, no major bump):
- `follow-redirects@<1.16.0 → >=1.16.0` (GHSA-r4q5-vmmm-2653), was 1.15.11, due 2026-07-01.

`axios` and `vite` advisories are handled by Renovate PRs #73 and #83 respectively.

### How to test

`pnpm install`; `pnpm why follow-redirects` — resolves to 1.16.0.