### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
           npm ci && npm run build
 
       - name: Zephyr Preview Environments
-        uses: ZephyrCloudIO/zephyr-preview-environment-action@v0.2.0
+        uses: ZephyrCloudIO/zephyr-preview-environment-action@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -96,7 +96,7 @@ To post as a Zephyr-branded bot:
        private-key: ${{ secrets.ZEPHYR_APP_PRIVATE_KEY }}
 
    - name: Zephyr Preview Environments
-     uses: ZephyrCloudIO/zephyr-preview-environment-action@v0.2.0
+     uses: ZephyrCloudIO/zephyr-preview-environment-action@v1.0.0
      with:
        github_token: ${{ steps.zephyr-app-token.outputs.token }}
    ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zephyr-preview-environments-action",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Create preview environments using Zephyr (PR-only action)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare the Zephyr Preview Environments action for its stable `v1.0.0` release.

## Changes

- bump the package version from `0.2.0` to `1.0.0`
- update README workflow examples to consume `@v1.0.0`

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm build`
- `pnpm exec tsc --noEmit`
- `pnpm exec ultracite check README.md package.json src test`
